### PR TITLE
Updates to parse_hack_tree_sitter

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.mli
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.mli
@@ -1,4 +1,7 @@
 val parse :
-  Common.filename -> AST_generic.program Tree_sitter_run.Parsing_result.t
+  Common.filename -> 
+  AST_generic.program Tree_sitter_run.Parsing_result.t
 
-val parse_pattern : string -> AST_generic.any Tree_sitter_run.Parsing_result.t
+val parse_pattern : 
+  string -> 
+  AST_generic.any Tree_sitter_run.Parsing_result.t


### PR DESCRIPTION
Here are some of the fixes I made this evening. I'm not sure why we're getting the following error, and I'm definitely missing something:

```
This expression has type PI.token_mutable stack
but an expression was expected of type AST.stmt stack
Type PI.token_mutable is not compatible with type AST.stmt
```

When the script function is called, it breaks the code down into the hh header and then a list of statements. I think we may want it to return a list of expressions instead so they can be further processed. That'll mean modifying the type of CST.script since it currently is defined as a token and a list of statements. 

The big problem here is that I'm not sure why the type is still a Parse_info.token_mutable. Parse_info.token_mutable is aliased to Parse_info.t: 

`type t = token_mutable`

and I'm not sure how to go from PI.t to AST.stmt. Might want to have Ryan take a look in the morning.

